### PR TITLE
Add initial Chime+ PNC model with comparisons

### DIFF
--- a/AlgebraicJulia_models/chime+.json
+++ b/AlgebraicJulia_models/chime+.json
@@ -1,0 +1,455 @@
+{
+  "junctions": [
+    {
+      "value_type": "Float",
+      "name": "S",
+      "uid": "J:S",
+      "metadata": null,
+      "value": null,
+      "type": "State",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "I_U",
+      "uid": "J:I_U",
+      "metadata": null,
+      "value": null,
+      "type": "State",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "V",
+      "uid": "J:V",
+      "metadata": null,
+      "value": null,
+      "type": "State",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "R",
+      "uid": "J:R",
+      "metadata": null,
+      "value": null,
+      "type": "State",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "I_V",
+      "uid": "J:I_V",
+      "metadata": null,
+      "value": null,
+      "type": "State",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "rec_v",
+      "uid": "J:rec_v",
+      "metadata": null,
+      "value": null,
+      "type": "Rate",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "inf_vv",
+      "uid": "J:inf_vv",
+      "metadata": null,
+      "value": null,
+      "type": "Rate",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "inf_vu",
+      "uid": "J:inf_vu",
+      "metadata": null,
+      "value": null,
+      "type": "Rate",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "inf_uu",
+      "uid": "J:inf_uu",
+      "metadata": null,
+      "value": null,
+      "type": "Rate",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "inf_uv",
+      "uid": "J:inf_uv",
+      "metadata": null,
+      "value": null,
+      "type": "Rate",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "vax",
+      "uid": "J:vax",
+      "metadata": null,
+      "value": null,
+      "type": "Rate",
+      "syntax": "Junction"
+    },
+    {
+      "value_type": "Float",
+      "name": "rec_u",
+      "uid": "J:rec_u",
+      "metadata": null,
+      "value": null,
+      "type": "Rate",
+      "syntax": "Junction"
+    }
+  ],
+  "root": "B:SimpleChime+",
+  "wires": [
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:I_V.rec_v",
+      "src": "J:I_V",
+      "tgt": "J:rec_v",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:V.inf_vv",
+      "src": "J:V",
+      "tgt": "J:inf_vv",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:I_V.inf_vv",
+      "src": "J:I_V",
+      "tgt": "J:inf_vv",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:S.inf_vu",
+      "src": "J:S",
+      "tgt": "J:inf_vu",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:I_V.inf_vu",
+      "src": "J:I_V",
+      "tgt": "J:inf_vu",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:S.inf_uu",
+      "src": "J:S",
+      "tgt": "J:inf_uu",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:I_U.inf_uu",
+      "src": "J:I_U",
+      "tgt": "J:inf_uu",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:V.inf_uv",
+      "src": "J:V",
+      "tgt": "J:inf_uv",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:I_U.inf_uv",
+      "src": "J:I_U",
+      "tgt": "J:inf_uv",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:S.vax",
+      "src": "J:S",
+      "tgt": "J:vax",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:I_U.rec_u",
+      "src": "J:I_U",
+      "tgt": "J:rec_u",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:rec_v.R",
+      "src": "J:rec_v",
+      "tgt": "J:R",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:inf_vv.I_V",
+      "src": "J:inf_vv",
+      "tgt": "J:I_V",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:inf_vv.I_V_0",
+      "src": "J:inf_vv",
+      "tgt": "J:I_V",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:inf_vu.I_U",
+      "src": "J:inf_vu",
+      "tgt": "J:I_U",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:inf_vu.I_V",
+      "src": "J:inf_vu",
+      "tgt": "J:I_V",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:inf_uu.I_U",
+      "src": "J:inf_uu",
+      "tgt": "J:I_U",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:inf_uu.I_U_0",
+      "src": "J:inf_uu",
+      "tgt": "J:I_U",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:inf_uv.I_V",
+      "src": "J:inf_uv",
+      "tgt": "J:I_V",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:inf_uv.I_U",
+      "src": "J:inf_uv",
+      "tgt": "J:I_U",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:vax.V",
+      "src": "J:vax",
+      "tgt": "J:V",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    },
+    {
+      "value_type": null,
+      "name": null,
+      "uid": "W:rec_u.R",
+      "src": "J:rec_u",
+      "tgt": "J:R",
+      "metadata": null,
+      "value": null,
+      "type": null,
+      "syntax": "Wire"
+    }
+  ],
+  "types": null,
+  "name": "SimpleChime+",
+  "variables": null,
+  "literals": null,
+  "uid": "SimpleChime+PetriNetClassic",
+  "boxes": [
+    {
+      "junctions": [
+        "J:S",
+        "J:I_U",
+        "J:V",
+        "J:R",
+        "J:I_V",
+        "J:rec_v",
+        "J:inf_vv",
+        "J:inf_vu",
+        "J:inf_uu",
+        "J:inf_uv",
+        "J:vax",
+        "J:rec_u"
+      ],
+      "syntax": "Relation",
+      "name": "SimpleChime+",
+      "uid": "B:SimpleChime+",
+      "ports": null,
+      "boxes": null,
+      "metadata": null,
+      "type": null,
+      "wires": [
+        "W:I_V.rec_v",
+        "W:V.inf_vv",
+        "W:I_V.inf_vv",
+        "W:S.inf_vu",
+        "W:I_V.inf_vu",
+        "W:S.inf_uu",
+        "W:I_U.inf_uu",
+        "W:V.inf_uv",
+        "W:I_U.inf_uv",
+        "W:S.vax",
+        "W:I_U.rec_u",
+        "W:rec_v.R",
+        "W:inf_vv.I_V",
+        "W:inf_vv.I_V_0",
+        "W:inf_vu.I_U",
+        "W:inf_vu.I_V",
+        "W:inf_uu.I_U",
+        "W:inf_uu.I_U_0",
+        "W:inf_uv.I_V",
+        "W:inf_uv.I_U",
+        "W:vax.V",
+        "W:rec_u.R"
+      ]
+    }
+  ],
+  "ports": null,
+  "metadata": [
+    {
+      "provenance": {
+        "method": "FromPNC_baas@gt",
+        "timestamp": "2021-07-23T14:38:597310_UTC-0000",
+        "metadata_type": "Provenance"
+      },
+      "variables": [
+        "J:S",
+        "J:I_U",
+        "J:V",
+        "J:R",
+        "J:I_V",
+        "J:rec_v",
+        "J:inf_vv",
+        "J:inf_vu",
+        "J:inf_uu",
+        "J:inf_uv",
+        "J:vax",
+        "J:rec_u"
+      ],
+      "parameters": [
+        "J:rec_v",
+        "J:inf_vv",
+        "J:inf_vu",
+        "J:inf_uu",
+        "J:inf_uv",
+        "J:vax",
+        "J:rec_u"
+      ],
+      "uid": "SimpleChime+_PNC_model_interface",
+      "metadata_type": "ModelInterface",
+      "initial_conditions": [
+        "J:S",
+        "J:I_U",
+        "J:V",
+        "J:R",
+        "J:I_V"
+      ]
+    }
+  ],
+  "type": "PetriNetClassic",
+  "syntax": "Gromet"
+}

--- a/AlgebraicJulia_models/model_comparisons/Readme.md
+++ b/AlgebraicJulia_models/model_comparisons/Readme.md
@@ -31,3 +31,6 @@ The structure is as follows:
 - *legs*: The list of models which have maps from the apex model
 	- *ModelUID*: A list of all structure-preserving maps from ModelUID to the apex model
 		- *Maps*: These arrays are maps by UID of elements from the apex to elements of the ModelUID model.
+
+Following is a visualization of the `json` provided above, which shows the connections between the SIR model and the Chime+ model. Note that there are two structure-preserving maps, so the visualization has arrows into two copies of the Chime+ model.
+![image](https://user-images.githubusercontent.com/19711695/126816017-80fe9ea3-2441-421d-96b6-39e588df5a08.png)

--- a/AlgebraicJulia_models/model_comparisons/Readme.md
+++ b/AlgebraicJulia_models/model_comparisons/Readme.md
@@ -1,0 +1,33 @@
+# Model Comparison Format
+
+The comparison files provided give the description of a span (maps from one
+*apex* model to potentially several other models). This description is provided
+in a `json` file with the following format:
+```json
+{
+  "apex": "SimpleSIR_PetriNetClassic",
+  "legs": {
+    "SimpleChime+PetriNetClassic": [
+      {
+        "J:gamma": "J:rec_u",
+        "J:I": "J:I_U",
+        "J:R": "J:R",
+        "J:S": "J:S",
+        "J:beta": "J:inf_uu"
+      },
+      {
+        "J:gamma": "J:rec_v",
+        "J:I": "J:I_V",
+        "J:R": "J:R",
+        "J:S": "J:V",
+        "J:beta": "J:inf_vv"
+      }
+    ]
+  }
+}
+```
+The structure is as follows:
+- *apex*: The UID of the apex model
+- *legs*: The list of models which have maps from the apex model
+	- *ModelUID*: A list of all structure-preserving maps from ModelUID to the apex model
+		- *Maps*: These arrays are maps by UID of elements from the apex to elements of the ModelUID model.

--- a/AlgebraicJulia_models/model_comparisons/sir_chime+.json
+++ b/AlgebraicJulia_models/model_comparisons/sir_chime+.json
@@ -1,0 +1,21 @@
+{
+  "apex": "SimpleSIR_PetriNetClassic",
+  "legs": {
+    "SimpleChime+PetriNetClassic": [
+      {
+        "J:gamma": "J:rec_u",
+        "J:I": "J:I_U",
+        "J:R": "J:R",
+        "J:S": "J:S",
+        "J:beta": "J:inf_uu"
+      },
+      {
+        "J:gamma": "J:rec_v",
+        "J:I": "J:I_V",
+        "J:R": "J:R",
+        "J:S": "J:V",
+        "J:beta": "J:inf_vv"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds the SVIIR (Chime+) PNC model gromet, along with a potential format for structural model comparisons. Since we will be iterating with Uncharted on the model comparison format, this PR will start as a WIP.