### PR TITLE
Add somewhat sensible default values to AlgebraicJulia models

### DIFF
--- a/AlgebraicJulia_models/3_city_seird.json
+++ b/AlgebraicJulia_models/3_city_seird.json
@@ -5,7 +5,15 @@
       "name": "S_1",
       "uid": "J:S_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "997.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -14,7 +22,15 @@
       "name": "E_1",
       "uid": "J:E_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "3.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -23,7 +39,15 @@
       "name": "I_1",
       "uid": "J:I_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -32,7 +56,15 @@
       "name": "R_1",
       "uid": "J:R_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -41,7 +73,15 @@
       "name": "D_1",
       "uid": "J:D_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -50,7 +90,15 @@
       "name": "S_2",
       "uid": "J:S_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "1997.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -59,7 +107,15 @@
       "name": "E_2",
       "uid": "J:E_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "3.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -68,7 +124,15 @@
       "name": "I_2",
       "uid": "J:I_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -77,7 +141,15 @@
       "name": "R_2",
       "uid": "J:R_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -86,7 +158,15 @@
       "name": "D_2",
       "uid": "J:D_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -95,7 +175,15 @@
       "name": "S_3",
       "uid": "J:S_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "2997.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -104,7 +192,15 @@
       "name": "E_3",
       "uid": "J:E_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "3.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -113,7 +209,15 @@
       "name": "I_3",
       "uid": "J:I_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -122,7 +226,15 @@
       "name": "R_3",
       "uid": "J:R_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -131,7 +243,15 @@
       "name": "D_3",
       "uid": "J:D_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -140,7 +260,15 @@
       "name": "inf_1",
       "uid": "J:inf_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.3"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -149,7 +277,15 @@
       "name": "rec_1",
       "uid": "J:rec_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.04"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -158,7 +294,15 @@
       "name": "exp_1",
       "uid": "J:exp_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0006"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -167,7 +311,15 @@
       "name": "death_1",
       "uid": "J:death_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.02"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -176,7 +328,15 @@
       "name": "inf_2",
       "uid": "J:inf_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.3"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -185,7 +345,15 @@
       "name": "rec_2",
       "uid": "J:rec_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.04"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -194,7 +362,15 @@
       "name": "exp_2",
       "uid": "J:exp_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0004"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -203,7 +379,15 @@
       "name": "death_2",
       "uid": "J:death_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.02"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -212,7 +396,15 @@
       "name": "inf_3",
       "uid": "J:inf_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.3"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -221,7 +413,15 @@
       "name": "rec_3",
       "uid": "J:rec_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.04"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -230,7 +430,15 @@
       "name": "exp_3",
       "uid": "J:exp_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.00025"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -239,7 +447,15 @@
       "name": "death_3",
       "uid": "J:death_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.02"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -248,7 +464,15 @@
       "name": "diff_S_1_2",
       "uid": "J:diff_S_1_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.02"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -257,7 +481,15 @@
       "name": "diff_E_1_2",
       "uid": "J:diff_E_1_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.01"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -266,7 +498,15 @@
       "name": "diff_I_1_2",
       "uid": "J:diff_I_1_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -275,7 +515,15 @@
       "name": "diff_R_1_2",
       "uid": "J:diff_R_1_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.02"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -284,7 +532,15 @@
       "name": "diff_S_2_1",
       "uid": "J:diff_S_2_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.01"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -293,7 +549,15 @@
       "name": "diff_E_2_1",
       "uid": "J:diff_E_2_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.005"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -302,7 +566,15 @@
       "name": "diff_I_2_1",
       "uid": "J:diff_I_2_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -311,7 +583,15 @@
       "name": "diff_R_2_1",
       "uid": "J:diff_R_2_1",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.012"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -320,7 +600,15 @@
       "name": "diff_S_2_3",
       "uid": "J:diff_S_2_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.03"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -329,7 +617,15 @@
       "name": "diff_E_2_3",
       "uid": "J:diff_E_2_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.01"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -338,7 +634,15 @@
       "name": "diff_I_2_3",
       "uid": "J:diff_I_2_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -347,7 +651,15 @@
       "name": "diff_R_2_3",
       "uid": "J:diff_R_2_3",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.032"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -356,7 +668,15 @@
       "name": "diff_S_3_2",
       "uid": "J:diff_S_3_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.025"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -365,7 +685,15 @@
       "name": "diff_E_3_2",
       "uid": "J:diff_E_3_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.01"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -374,7 +702,15 @@
       "name": "diff_I_3_2",
       "uid": "J:diff_I_3_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -383,7 +719,15 @@
       "name": "diff_R_3_2",
       "uid": "J:diff_R_3_2",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.005"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     }

--- a/AlgebraicJulia_models/seir.json
+++ b/AlgebraicJulia_models/seir.json
@@ -5,7 +5,15 @@
       "name": "S",
       "uid": "J:S",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "997.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -14,7 +22,15 @@
       "name": "E",
       "uid": "J:E",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "3.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -23,7 +39,15 @@
       "name": "I",
       "uid": "J:I",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -32,7 +56,15 @@
       "name": "R",
       "uid": "J:R",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -41,7 +73,15 @@
       "name": "inf",
       "uid": "J:inf",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.3"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -50,7 +90,15 @@
       "name": "rec",
       "uid": "J:rec",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.04"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -59,7 +107,15 @@
       "name": "exp",
       "uid": "J:exp",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0004"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     }

--- a/AlgebraicJulia_models/seird.json
+++ b/AlgebraicJulia_models/seird.json
@@ -5,7 +5,15 @@
       "name": "S",
       "uid": "J:S",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "997.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -14,7 +22,15 @@
       "name": "E",
       "uid": "J:E",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "3.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -23,7 +39,15 @@
       "name": "I",
       "uid": "J:I",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -32,7 +56,15 @@
       "name": "R",
       "uid": "J:R",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -41,7 +73,15 @@
       "name": "D",
       "uid": "J:D",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -50,7 +90,15 @@
       "name": "inf",
       "uid": "J:inf",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.3"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -59,7 +107,15 @@
       "name": "rec",
       "uid": "J:rec",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.04"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -68,7 +124,15 @@
       "name": "exp",
       "uid": "J:exp",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0004"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -77,7 +141,15 @@
       "name": "death",
       "uid": "J:death",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.02"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     }

--- a/AlgebraicJulia_models/sird.json
+++ b/AlgebraicJulia_models/sird.json
@@ -5,7 +5,15 @@
       "name": "S",
       "uid": "J:S",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "997.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -14,7 +22,15 @@
       "name": "I",
       "uid": "J:I",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "3.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -23,7 +39,15 @@
       "name": "R",
       "uid": "J:R",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -32,7 +56,15 @@
       "name": "D",
       "uid": "J:D",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0"
+        },
+        "metadata": null
+      },
       "type": "State",
       "syntax": "Junction"
     },
@@ -41,7 +73,15 @@
       "name": "inf",
       "uid": "J:inf",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.0004"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -50,7 +90,15 @@
       "name": "rec",
       "uid": "J:rec",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.04"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     },
@@ -59,7 +107,15 @@
       "name": "death",
       "uid": "J:death",
       "metadata": null,
-      "value": null,
+      "value": {
+        "type": "Float",
+        "syntax": "Literal",
+        "value": {
+          "syntax": "Val",
+          "val": "0.02"
+        },
+        "metadata": null
+      },
       "type": "Rate",
       "syntax": "Junction"
     }


### PR DESCRIPTION
@bosonbaas, this PR modifies the models you've provided us to include some default values that make the models runnable off-the-shelf. I can't say with certainty that they're all epidemiologically sound, but they do showcase a somewhat representative case of each model's behavior.