### PR TITLE
Adding ModelDescription metadata to Simple_SIR models

### DIFF
--- a/Simple_SIR/SimpleSIR_metadata_gromet_Bilayer.json
+++ b/Simple_SIR/SimpleSIR_metadata_gromet_Bilayer.json
@@ -3,6 +3,17 @@
   "type": "Bilayer",
   "name": "SimpleSIR_metadata",
   "metadata": [
+  	{
+  		"metadata_type": "ModelDescription",
+  		"uid": "simple_sir_model_description",
+  		"provenance": {
+  			"metadata_type": "Provenance",
+        "method": "Manual_claytonm@az",
+        "timestamp": "2021-06-23T09:38:34:684350_MST-0700"
+  		},
+  		"name": "The SIR Model without vital dynamics",
+  		"description": "The Simple SIR model is a simplified implementation of a compartmental model for modeling infectious disease. The population is assigned to compartments with labels – for example, S, I, or R, (Susceptible, Infectious, or Recovered). This model is implemented using simple ordinary differential equations, representing deterministic dynamics."
+  	},
     {
       "metadata_type": "ModelInterface",
       "uid": "simple_sir_BL_model_interface",

--- a/Simple_SIR/SimpleSIR_metadata_gromet_FunctionNetwork.json
+++ b/Simple_SIR/SimpleSIR_metadata_gromet_FunctionNetwork.json
@@ -3,6 +3,17 @@
   "type": "FunctionNetwork",
   "name": "SimpleSIR_metadata",
   "metadata": [
+  	{
+  		"metadata_type": "ModelDescription",
+  		"uid": "simple_sir_model_description",
+  		"provenance": {
+  			"metadata_type": "Provenance",
+        "method": "Manual_claytonm@az",
+        "timestamp": "2021-06-23T09:38:34:684350_MST-0700"
+  		},
+  		"name": "The SIR Model without vital dynamics",
+  		"description": "The Simple SIR model is a simplified implementation of a compartmental model for modeling infectious disease. The population is assigned to compartments with labels – for example, S, I, or R, (Susceptible, Infectious, or Recovered). This model is implemented using simple ordinary differential equations, representing deterministic dynamics."
+  	},
     {
       "metadata_type": "ModelInterface",
       "uid": "simple_sir_model_interface",

--- a/Simple_SIR/SimpleSIR_metadata_gromet_PetriNetClassic.json
+++ b/Simple_SIR/SimpleSIR_metadata_gromet_PetriNetClassic.json
@@ -3,6 +3,17 @@
   "type": "PetriNetClassic",
   "name": "SimpleSIR_metadata",
   "metadata": [
+  	{
+  		"metadata_type": "ModelDescription",
+  		"uid": "simple_sir_model_description",
+  		"provenance": {
+  			"metadata_type": "Provenance",
+        "method": "Manual_claytonm@az",
+        "timestamp": "2021-06-23T09:38:34:684350_MST-0700"
+  		},
+  		"name": "The SIR Model without vital dynamics",
+  		"description": "The Simple SIR model is a simplified implementation of a compartmental model for modeling infectious disease. The population is assigned to compartments with labels – for example, S, I, or R, (Susceptible, Infectious, or Recovered). This model is implemented using simple ordinary differential equations, representing deterministic dynamics."
+  	},
     {
       "metadata_type": "ModelInterface",
       "uid": "simple_sir_PNC_model_interface",


### PR DESCRIPTION
Adding ModelDescription metadata to Simple_SIR models, including FunctionNetwork, PetriNetClassic and Bilayer.