### PR TITLE
Update EMMAA COVID-19 inflammasome model

### DIFF
--- a/emmaa_models/covid19_inflammasome_gromet_2021-08-23-20-14-54.json
+++ b/emmaa_models/covid19_inflammasome_gromet_2021-08-23-20-14-54.json
@@ -9,7 +9,7 @@
       "provenance": {
         "metadata_type": "Provenance",
         "method": "from_emmaa_model",
-        "timestamp": "2021-08-18T19:49:23:683470_MST-0700"
+        "timestamp": "2021-08-23T20:14:54:682407_MST-0700"
       },
       "variables": [
         "J:mitochondrion()",
@@ -237,7 +237,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:676663_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677307_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -272,7 +272,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:676807_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677399_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -310,7 +310,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:676856_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677439_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -353,7 +353,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:676903_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677473_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -395,7 +395,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:676941_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677505_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -438,7 +438,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677009_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677536_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -480,7 +480,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677053_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677566_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -519,7 +519,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677096_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677596_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -560,7 +560,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677131_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677626_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -599,7 +599,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677166_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677656_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -641,7 +641,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677200_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677685_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -681,7 +681,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677234_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677714_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -723,15 +723,15 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677268_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677743_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "TXN",
               "db_refs": {
-                "EGID": "7295",
                 "UP": "P10599",
                 "HGNC": "12435",
+                "EGID": "7295",
                 "ENSEMBL": "ENSG00000136810",
                 "REFSEQ_PROT": "NM_001244938",
                 "MESH": "C491203"
@@ -765,16 +765,16 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677305_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677775_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "calcium_2__",
               "db_refs": {
+                "HMDB": "HMDB0000464",
                 "CHEBI": "CHEBI:29108",
                 "PUBCHEM": "271",
-                "CAS": "14127-61-8",
-                "HMDB": "HMDB0000464"
+                "CAS": "14127-61-8"
               }
             }
           ]
@@ -805,7 +805,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677342_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677804_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -843,7 +843,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677380_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677833_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -880,7 +880,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677419_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677894_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -923,7 +923,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677454_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677941_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -963,7 +963,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677488_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677970_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1003,7 +1003,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677522_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:677999_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1014,7 +1014,8 @@
                 "HGNC": "1499",
                 "EGID": "834",
                 "ENSEMBL": "ENSG00000137752",
-                "REFSEQ_PROT": "NM_033292"
+                "REFSEQ_PROT": "NM_033292",
+                "DRUGBANKV4.TARGET": "BE0000444"
               }
             }
           ]
@@ -1045,7 +1046,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677556_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678071_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1085,16 +1086,16 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677590_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678144_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "IL1B",
               "db_refs": {
                 "UP": "P01584",
-                "EGID": "3553",
-                "MESH": "D053583",
-                "HGNC": "5992"
+                "HGNC": "5992",
+                "MESH": "C508585",
+                "EGID": "3553"
               }
             }
           ]
@@ -1125,14 +1126,14 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677624_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678173_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "PYCARD",
               "db_refs": {
-                "UP": "Q9ULZ3",
                 "HGNC": "16608",
+                "UP": "Q9ULZ3",
                 "EGID": "29108",
                 "MESH": "C402202"
               }
@@ -1165,7 +1166,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677658_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678201_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1207,7 +1208,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677695_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678258_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1246,14 +1247,13 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677730_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678303_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "E",
               "db_refs": {
                 "UP": "P59637",
-                "TAXONOMY": "694009",
                 "EGID": "1489671"
               }
             }
@@ -1285,7 +1285,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677769_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678332_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1322,12 +1322,17 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677811_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678360_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "Pralnacasan",
-              "db_refs": {}
+              "db_refs": {
+                "DRUGBANK": "DB04875",
+                "CAS": "192755-52-5",
+                "PUBCHEM": "153270",
+                "CHEMBL": "CHEMBL437526"
+              }
             }
           ]
         }
@@ -1357,16 +1362,13 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677847_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678396_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "parthenolide",
               "db_refs": {
-                "PUBCHEM": "7251185",
-                "CHEBI": "CHEBI:7939",
-                "CAS": "20554-84-1",
-                "CHEMBL": "CHEMBL388727"
+                "CHEBI": "CHEBI:7939"
               }
             }
           ]
@@ -1397,14 +1399,14 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:677882_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678426_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "IKBKB",
               "db_refs": {
-                "UP": "O14920",
-                "HGNC": "5960"
+                "HGNC": "5960",
+                "UP": "O14920"
               }
             }
           ]
@@ -1435,13 +1437,17 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678031_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678459_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "_E__3_tosylacrylonitrile",
               "db_refs": {
-                "CHEBI": "CHEBI:85928"
+                "PUBCHEM": "5353431",
+                "HMS-LINCS": "10459",
+                "CHEBI": "CHEBI:85928",
+                "CAS": "19542-67-7",
+                "CHEMBL": "CHEMBL403183"
               }
             }
           ]
@@ -1472,7 +1478,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678072_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678522_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1509,7 +1515,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678112_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678556_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1547,7 +1553,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678152_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678594_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1589,7 +1595,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678191_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678643_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1632,7 +1638,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678228_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678674_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1674,7 +1680,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678270_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678705_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1713,7 +1719,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678326_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678737_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1754,7 +1760,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678365_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678768_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1796,7 +1802,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678415_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678798_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1836,7 +1842,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678457_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678831_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -1879,16 +1885,16 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678505_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678863_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "calcium_2__",
               "db_refs": {
+                "HMDB": "HMDB0000464",
                 "CHEBI": "CHEBI:29108",
                 "PUBCHEM": "271",
-                "CAS": "14127-61-8",
-                "HMDB": "HMDB0000464"
+                "CAS": "14127-61-8"
               }
             }
           ]
@@ -1919,15 +1925,15 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678553_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678894_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "TXN",
               "db_refs": {
-                "EGID": "7295",
                 "UP": "P10599",
                 "HGNC": "12435",
+                "EGID": "7295",
                 "ENSEMBL": "ENSG00000136810",
                 "REFSEQ_PROT": "NM_001244938",
                 "MESH": "C491203"
@@ -1961,7 +1967,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678593_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678929_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -2001,14 +2007,14 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678631_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678961_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "PYCARD",
               "db_refs": {
-                "UP": "Q9ULZ3",
                 "HGNC": "16608",
+                "UP": "Q9ULZ3",
                 "EGID": "29108",
                 "MESH": "C402202"
               }
@@ -2041,7 +2047,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678668_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:678992_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -2081,7 +2087,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678706_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679022_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -2092,7 +2098,8 @@
                 "HGNC": "1499",
                 "EGID": "834",
                 "ENSEMBL": "ENSG00000137752",
-                "REFSEQ_PROT": "NM_033292"
+                "REFSEQ_PROT": "NM_033292",
+                "DRUGBANKV4.TARGET": "BE0000444"
               }
             }
           ]
@@ -2123,7 +2130,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678742_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679056_MST-0700"
           },
           "indra_agent_references": [
             {
@@ -2163,16 +2170,16 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678781_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679091_MST-0700"
           },
           "indra_agent_references": [
             {
               "name": "IL1B",
               "db_refs": {
                 "UP": "P01584",
-                "EGID": "3553",
-                "MESH": "D053583",
-                "HGNC": "5992"
+                "HGNC": "5992",
+                "MESH": "C508585",
+                "EGID": "3553"
               }
             }
           ]
@@ -2203,7 +2210,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:678863_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679149_MST-0700"
           },
           "indra_stmt_hash": 12835542771633591,
           "reaction_rule": "mitochondrion_activates_reactive_oxygen_species_activity",
@@ -2235,7 +2242,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679013_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679260_MST-0700"
           },
           "indra_stmt_hash": -33791666966162263,
           "reaction_rule": "dioxygen_activates_water_activity",
@@ -2267,7 +2274,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679159_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679315_MST-0700"
           },
           "indra_stmt_hash": -23254141572933850,
           "reaction_rule": "dioxygen_activates_biliverdin_activity",
@@ -2299,7 +2306,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679268_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679366_MST-0700"
           },
           "indra_stmt_hash": -19358276560732315,
           "reaction_rule": "dioxygen_activates_carbon_monoxide_activity",
@@ -2331,7 +2338,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679365_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679426_MST-0700"
           },
           "indra_stmt_hash": -20462194123865485,
           "reaction_rule": "dioxygen_activates_NADP____activity",
@@ -2363,7 +2370,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679434_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679486_MST-0700"
           },
           "indra_stmt_hash": -9172999005745561,
           "reaction_rule": "dioxygen_activates_iron_2___activity",
@@ -2395,7 +2402,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679501_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679537_MST-0700"
           },
           "indra_stmt_hash": -20108495150093595,
           "reaction_rule": "hyaluronic_acid_activates_NLRP3_activity",
@@ -2427,7 +2434,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679591_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679592_MST-0700"
           },
           "indra_stmt_hash": 8423295275635649,
           "reaction_rule": "hyaluronic_acid_activates_SUGT1_activity",
@@ -2459,7 +2466,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679707_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679646_MST-0700"
           },
           "indra_stmt_hash": -33615998528389900,
           "reaction_rule": "NADPH_activates_water_activity",
@@ -2491,7 +2498,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679784_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679697_MST-0700"
           },
           "indra_stmt_hash": 27449522310373503,
           "reaction_rule": "NADPH_activates_biliverdin_activity",
@@ -2523,7 +2530,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679851_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679807_MST-0700"
           },
           "indra_stmt_hash": -27109350041880053,
           "reaction_rule": "NADPH_activates_carbon_monoxide_activity",
@@ -2555,7 +2562,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679924_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679866_MST-0700"
           },
           "indra_stmt_hash": -28402272758547468,
           "reaction_rule": "NADPH_activates_NADP____activity",
@@ -2587,7 +2594,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:679993_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679923_MST-0700"
           },
           "indra_stmt_hash": -2549998563827919,
           "reaction_rule": "NADPH_activates_iron_2___activity",
@@ -2619,7 +2626,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680061_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:679988_MST-0700"
           },
           "indra_stmt_hash": -18389485349912460,
           "reaction_rule": "heme_activates_water_activity",
@@ -2651,7 +2658,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680125_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680046_MST-0700"
           },
           "indra_stmt_hash": -34850584861702653,
           "reaction_rule": "heme_activates_biliverdin_activity",
@@ -2683,7 +2690,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680192_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680101_MST-0700"
           },
           "indra_stmt_hash": -20247715615526404,
           "reaction_rule": "heme_activates_carbon_monoxide_activity",
@@ -2715,7 +2722,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680295_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680158_MST-0700"
           },
           "indra_stmt_hash": -26807453749483019,
           "reaction_rule": "heme_activates_NADP____activity",
@@ -2747,7 +2754,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680388_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680218_MST-0700"
           },
           "indra_stmt_hash": -14335330989363216,
           "reaction_rule": "heme_activates_iron_2___activity",
@@ -2779,7 +2786,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680462_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680272_MST-0700"
           },
           "indra_stmt_hash": -7900295090152057,
           "reaction_rule": "pattern_recognition_receptor_signaling_pathway_activates_NLRP3_activity",
@@ -2811,7 +2818,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680535_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680329_MST-0700"
           },
           "indra_stmt_hash": -33026345100004448,
           "reaction_rule": "pattern_recognition_receptor_signaling_pathway_activates_SUGT1_activity",
@@ -2843,7 +2850,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680630_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680401_MST-0700"
           },
           "indra_stmt_hash": 9482328515580424,
           "reaction_rule": "HMOX1_activates_water_activity",
@@ -2875,7 +2882,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680737_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680467_MST-0700"
           },
           "indra_stmt_hash": 4165033709137679,
           "reaction_rule": "HMOX1_activates_biliverdin_activity",
@@ -2907,7 +2914,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680846_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680530_MST-0700"
           },
           "indra_stmt_hash": 20810695862211085,
           "reaction_rule": "HMOX1_activates_carbon_monoxide_activity",
@@ -2939,7 +2946,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:680933_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680592_MST-0700"
           },
           "indra_stmt_hash": -32006360760956236,
           "reaction_rule": "HMOX1_activates_NADP____activity",
@@ -2971,7 +2978,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681017_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680660_MST-0700"
           },
           "indra_stmt_hash": -4429435735465789,
           "reaction_rule": "HMOX1_activates_iron_2___activity",
@@ -3003,7 +3010,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681118_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680723_MST-0700"
           },
           "indra_stmt_hash": 7825810811169163,
           "reaction_rule": "p3a_activates_TRAF3_activity",
@@ -3035,7 +3042,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681213_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680785_MST-0700"
           },
           "indra_stmt_hash": -24735111122940356,
           "reaction_rule": "E_activates_calcium_2___activity",
@@ -3067,7 +3074,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681314_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680848_MST-0700"
           },
           "indra_stmt_hash": 3979344232136451,
           "reaction_rule": "Orf9b_degrades_TRAF3",
@@ -3099,9 +3106,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681389_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680912_MST-0700"
           },
-          "indra_stmt_hash": 23667018272748059,
+          "indra_stmt_hash": -25737957086774249,
           "reaction_rule": "reactive_oxygen_species_act_activates_TXN_activity",
           "is_reverse": false
         }
@@ -3131,9 +3138,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681518_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:680979_MST-0700"
           },
-          "indra_stmt_hash": -33112545592478985,
+          "indra_stmt_hash": 2199793515512423,
           "reaction_rule": "reactive_oxygen_species_act_activates_NLRP3_activity",
           "is_reverse": false
         }
@@ -3163,9 +3170,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681614_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681032_MST-0700"
           },
-          "indra_stmt_hash": 9483031281970413,
+          "indra_stmt_hash": 35577902845018382,
           "reaction_rule": "reactive_oxygen_species_act_activates_SUGT1_activity",
           "is_reverse": false
         }
@@ -3195,9 +3202,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681693_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681086_MST-0700"
           },
-          "indra_stmt_hash": -6899295879885749,
+          "indra_stmt_hash": -4112084227130961,
           "reaction_rule": "calcium_2___act_activates_NLRP3_activity",
           "is_reverse": false
         }
@@ -3227,9 +3234,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681772_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681142_MST-0700"
           },
-          "indra_stmt_hash": -11523416584483539,
+          "indra_stmt_hash": 20475454460888688,
           "reaction_rule": "calcium_2___act_activates_SUGT1_activity",
           "is_reverse": false
         }
@@ -3259,9 +3266,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681841_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681198_MST-0700"
           },
-          "indra_stmt_hash": 18750495497402700,
+          "indra_stmt_hash": 572255591318570,
           "reaction_rule": "TRAF3_act_activates_NFKB1_activity",
           "is_reverse": false
         }
@@ -3291,9 +3298,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:681931_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681253_MST-0700"
           },
-          "indra_stmt_hash": 17602490124120765,
+          "indra_stmt_hash": 21183686642852321,
           "reaction_rule": "NLRP3_act_activates_PYCARD_activity",
           "is_reverse": false
         }
@@ -3323,9 +3330,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682025_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681311_MST-0700"
           },
-          "indra_stmt_hash": 1380654838385392,
+          "indra_stmt_hash": -35670139379015031,
           "reaction_rule": "SUGT1_act_activates_NLRP3_activity",
           "is_reverse": false
         }
@@ -3355,7 +3362,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682100_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681375_MST-0700"
           },
           "indra_stmt_hash": 3979344232136451,
           "reaction_rule": "Orf9b_degrades_TRAF3",
@@ -3387,9 +3394,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682179_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681437_MST-0700"
           },
-          "indra_stmt_hash": 29747368600195804,
+          "indra_stmt_hash": -28181906943383997,
           "reaction_rule": "carbon_monoxide_act_deactivates_reactive_oxygen_species_activity",
           "is_reverse": false
         }
@@ -3419,7 +3426,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682267_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681501_MST-0700"
           },
           "indra_stmt_hash": 21689955333705851,
           "reaction_rule": "parthenolide_deactivates_NLRP3_activity",
@@ -3451,7 +3458,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682355_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681565_MST-0700"
           },
           "indra_stmt_hash": -19046700989119558,
           "reaction_rule": "_E__3_tosylacrylonitrile_deactivates_NLRP3_activity",
@@ -3483,9 +3490,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682431_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681621_MST-0700"
           },
-          "indra_stmt_hash": -14607233151538371,
+          "indra_stmt_hash": -17107069648915433,
           "reaction_rule": "TXN_act_activates_TXNIP_activity",
           "is_reverse": false
         }
@@ -3515,9 +3522,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682504_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681683_MST-0700"
           },
-          "indra_stmt_hash": 3726856741857303,
+          "indra_stmt_hash": -31681694293676037,
           "reaction_rule": "PYCARD_act_activates_TRAF3_activity",
           "is_reverse": false
         }
@@ -3547,9 +3554,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682592_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681740_MST-0700"
           },
-          "indra_stmt_hash": -13187163498274087,
+          "indra_stmt_hash": -1728765402557376,
           "reaction_rule": "PYCARD_act_activates_CASP1_activity",
           "is_reverse": false
         }
@@ -3579,9 +3586,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682677_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681799_MST-0700"
           },
-          "indra_stmt_hash": -11050218521189594,
+          "indra_stmt_hash": 20782472249184147,
           "reaction_rule": "NFKB1_act_activates_IL18_activity",
           "is_reverse": false
         }
@@ -3611,9 +3618,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682763_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681863_MST-0700"
           },
-          "indra_stmt_hash": 21288829100978592,
+          "indra_stmt_hash": -17768770853302318,
           "reaction_rule": "NFKB1_act_activates_IL1B_activity",
           "is_reverse": false
         }
@@ -3643,9 +3650,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682853_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681922_MST-0700"
           },
-          "indra_stmt_hash": -10468666881688478,
+          "indra_stmt_hash": 12386768598887580,
           "reaction_rule": "CASP1_act_activates_IL18_activity",
           "is_reverse": false
         }
@@ -3675,9 +3682,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:682959_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:681977_MST-0700"
           },
-          "indra_stmt_hash": 23836089500517478,
+          "indra_stmt_hash": 30344210536609725,
           "reaction_rule": "CASP1_act_activates_IL1B_activity",
           "is_reverse": false
         }
@@ -3707,9 +3714,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:683054_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:682064_MST-0700"
           },
-          "indra_stmt_hash": 14060996188083641,
+          "indra_stmt_hash": -1945132131712719,
           "reaction_rule": "TXNIP_act_activates_NLRP3_activity",
           "is_reverse": false
         }
@@ -3739,9 +3746,9 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:683130_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:682146_MST-0700"
           },
-          "indra_stmt_hash": -13383633333682529,
+          "indra_stmt_hash": 33003285724052330,
           "reaction_rule": "TXNIP_act_activates_SUGT1_activity",
           "is_reverse": false
         }
@@ -3771,7 +3778,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:683205_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:682211_MST-0700"
           },
           "indra_stmt_hash": -6092028988306676,
           "reaction_rule": "Pralnacasan_deactivates_CASP1_activity",
@@ -3803,7 +3810,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:683278_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:682271_MST-0700"
           },
           "indra_stmt_hash": -691138474812308,
           "reaction_rule": "parthenolide_deactivates_CASP1_activity",
@@ -3835,7 +3842,7 @@
           "provenance": {
             "metadata_type": "Provenance",
             "method": "from_emmaa_model",
-            "timestamp": "2021-08-18T19:49:23:683356_MST-0700"
+            "timestamp": "2021-08-23T20:14:54:682335_MST-0700"
           },
           "indra_stmt_hash": -16803551771535351,
           "reaction_rule": "Proteasome_deactivates_IL18_activity",


### PR DESCRIPTION
For technical reasons, we need to update the EMMAA COVID-19 inflammasome model. The only change is to statement hash annotations, the model's structure and dynamics are unchanged.